### PR TITLE
Add modelling script and modelling/discussion report fragments

### DIFF
--- a/reports/fragments/06_data_modelling.qmd
+++ b/reports/fragments/06_data_modelling.qmd
@@ -1,1 +1,68 @@
-## Methods
+## Methods and Results — Modelling
+
+### LASSO Logistic Regression
+
+With the cleaned and preprocessed training data in hand, we fit a LASSO (Least Absolute Shrinkage and Selection Operator) logistic regression model using the `glmnet` package in R (@Li2022). LASSO is well suited to this dataset because the L1 penalty it applies during fitting can shrink the coefficients of irrelevant or redundant features exactly to zero, performing automatic feature selection alongside estimation. This is particularly useful given that our feature matrix — after one-hot encoding all categorical variables — is moderately high-dimensional.
+
+Before fitting, all numeric features are standardized (mean zero, unit variance) using parameters computed **only** from the training set. This is a critical step to prevent data leakage: the same training-set means and standard deviations are applied to the test set, so the model never indirectly learns from test data during preprocessing.
+
+We select the optimal regularization parameter, λ, through 10-fold cross-validation, maximizing the area under the ROC curve (AUC) as the selection criterion. @fig-cv-lambda shows how cross-validated AUC changes across the regularization path. The vertical dashed line marks the value of λ that maximizes AUC (`lambda.min`), which is used to fit the final model on the full training set.
+
+```{r}
+#| label: fig-cv-lambda
+#| fig-cap: "Cross-validated AUC across the LASSO regularization path. The left dashed line marks lambda.min (maximum AUC); the right marks lambda.1se."
+#| fig-width: 8
+#| fig-height: 5
+#| echo: false
+knitr::include_graphics(here::here("results/lasso_cv_plot.png"))
+```
+
+### Model Evaluation
+
+The final model is evaluated on the held-out 20% test set. We report four complementary metrics in @tbl-metrics: test AUC, accuracy, precision, and recall. Because the dataset is class-imbalanced (~84.5% non-purchase sessions), accuracy alone would be misleading; AUC and recall for the minority (purchase) class are the more informative indicators of real-world performance.
+
+```{r}
+#| label: tbl-metrics
+#| tbl-cap: "Summary of LASSO logistic regression performance on the held-out test set."
+#| echo: false
+library(tidyverse)
+library(knitr)
+metrics <- read_csv(here::here("results/model_metrics.csv"), show_col_types = FALSE)
+kable(metrics, col.names = c("Metric", "Value"), align = c("l", "r"))
+```
+
+The ROC curve for the test set is shown in @fig-roc. The curve traces the trade-off between true positive rate (sensitivity) and false positive rate (1 − specificity) across all classification thresholds, with a larger area under the curve indicating better discriminative ability. A random classifier would follow the diagonal dashed line (AUC = 0.5).
+
+```{r}
+#| label: fig-roc
+#| fig-cap: "ROC curve for the final LASSO model evaluated on the held-out test set."
+#| fig-width: 6
+#| fig-height: 5.5
+#| echo: false
+knitr::include_graphics(here::here("results/roc_curve.png"))
+```
+
+@tbl-confusion shows the confusion matrix, breaking down the model's predictions into true positives, true negatives, false positives, and false negatives. This reveals how the model balances identifying purchase sessions (the positive class) against avoiding false alarms.
+
+```{r}
+#| label: tbl-confusion
+#| tbl-cap: "Confusion matrix for the final LASSO model on the held-out test set (positive class = 'Yes', i.e. a purchase occurred)."
+#| echo: false
+cm <- read_csv(here::here("results/confusion_matrix.csv"), show_col_types = FALSE)
+cm_wide <- cm %>%
+  pivot_wider(names_from = Actual, values_from = Count) %>%
+  rename(Predicted = Predicted)
+kable(cm_wide)
+```
+
+### Selected Features
+
+@tbl-coef lists the features retained by LASSO (i.e., those with non-zero coefficients after regularization), ranked by absolute coefficient magnitude. A positive coefficient indicates a feature associated with a higher predicted probability of purchase, while a negative coefficient is associated with a lower probability.
+
+```{r}
+#| label: tbl-coef
+#| tbl-cap: "Non-zero LASSO coefficients for the final model, ranked by absolute magnitude."
+#| echo: false
+coef_df <- read_csv(here::here("results/lasso_coefficients.csv"), show_col_types = FALSE)
+kable(coef_df, col.names = c("Feature", "Coefficient"), digits = 4, align = c("l", "r"))
+```

--- a/reports/fragments/07_discussion.qmd
+++ b/reports/fragments/07_discussion.qmd
@@ -1,1 +1,21 @@
 ## Discussion
+
+### Summary of Findings
+
+Our LASSO logistic regression model demonstrates strong predictive ability for identifying online shopping sessions that will result in a purchase. The model achieves a test AUC well above 0.9, indicating that it can reliably distinguish purchasing from non-purchasing sessions across classification thresholds. Accuracy on the held-out test set is also high, though — given the class imbalance noted in @fig-roc and @tbl-confusion — the precision and recall figures for the positive (purchase) class are the more meaningful indicators of real-world utility.
+
+The LASSO penalty successfully reduced the feature space, retaining only the most informative predictors and setting the rest to zero (see @tbl-coef). The features with the largest positive coefficients align with intuitive expectations: page value (`PageValues`) is consistently the strongest predictor of purchase, reflecting that users who view high-value pages are more likely to convert. Behavioral signals such as time spent on product-related pages and lower bounce or exit rates also emerge as meaningful positive predictors. Conversely, sessions characterized by high exit rates or occurring in certain traffic sources are negatively associated with purchase intent.
+
+### Expected vs. Actual Results
+
+These results are broadly consistent with what we anticipated based on the existing literature. @Sakar2019 identified similar behavioral signals — particularly page value and exit rate — as key drivers of purchase intent. The strong performance of LASSO in this setting is also consistent with @Li2022, who demonstrated the effectiveness of L1-penalized models for imbalanced classification tasks. The one area of potential surprise is that the model performs well despite class imbalance (~84.5% negative class) without any resampling or class-weighting adjustments. This suggests that the predictive signal from the positive class is strong enough for LASSO to learn without additional balancing techniques.
+
+### Limitations and Impact
+
+Several limitations should be noted. First, the data was collected from a single e-commerce website over one year; the learned feature relationships may not generalize to other retail contexts, product categories, or time periods. Second, our analysis uses session-level aggregates (e.g. total time on product pages) rather than sequential clickstream data, which @Esmeli2021 showed can carry additional predictive signal for early intent prediction. Third, because we applied log1p transforms and factor collapsing based on the full training set, there is a minor risk that the specific collapsing thresholds (e.g., which `TrafficType` levels were merged into "Other") were chosen in a way that is somewhat dataset-specific.
+
+Despite these limitations, a model of this quality has meaningful practical implications. An e-commerce platform could integrate such a model to identify in real time which sessions are likely to convert, enabling targeted interventions — personalized promotions, proactive chat support, or curated product recommendations — at precisely the moments they are most likely to influence a purchase decision. Even modest improvements in conversion rate translate to substantial revenue gains at scale.
+
+### Future Directions
+
+This work raises several interesting follow-up questions. First, would incorporating sequential clickstream features (e.g., the order in which page types are visited) improve recall for the minority class, as suggested by @Esmeli2021? Second, would resampling techniques such as SMOTE, or class-weighted loss, improve recall for the positive class without sacrificing precision? Third, since the dataset spans a full year, temporal cross-validation — training on earlier months and testing on later ones — would provide a more realistic estimate of how the model performs when deployed prospectively. Finally, exploring non-linear models (e.g., gradient boosted trees) as a comparison baseline would clarify how much predictive signal is left on the table by the linear LASSO assumption.

--- a/src/04_model.R
+++ b/src/04_model.R
@@ -1,0 +1,171 @@
+# author: Athena Wong
+# date: 2026-03-18
+
+"This script fits a LASSO logistic regression model on the cleaned training data,
+evaluates it on the test set, and saves output figures and tables to results/.
+
+Usage: 04_model.R --train=<train> --test=<test> --output_dir=<output_dir>
+
+Options:
+--train=<train>            Path to training CSV (e.g. data/processed/train.csv)
+--test=<test>              Path to test CSV (e.g. data/processed/test.csv)
+--output_dir=<output_dir>  Directory to save output figures and tables (e.g. results/)
+" -> doc
+
+library(tidyverse)
+library(glmnet)
+library(pROC)
+library(caret)
+library(docopt)
+
+opt <- docopt(doc)
+
+main <- function(train_path, test_path, output_dir) {
+
+  # ── 0. Setup ──────────────────────────────────────────────────────────────
+  set.seed(310)
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+
+  # ── 1. Load data ──────────────────────────────────────────────────────────
+  train <- read_csv(train_path, show_col_types = FALSE) %>%
+    mutate(across(where(is.character), as.factor))
+
+  test <- read_csv(test_path, show_col_types = FALSE) %>%
+    mutate(across(where(is.character), as.factor))
+
+  # ── 2. Scale numeric features ─────────────────────────────────────────────
+  # Scaling is fit ONLY on training data to prevent data leakage.
+  # The same mean/sd is applied to the test set.
+  numeric_cols <- train %>% select(where(is.numeric)) %>% colnames()
+
+  train_means <- train %>% select(all_of(numeric_cols)) %>% summarise(across(everything(), mean))
+  train_sds   <- train %>% select(all_of(numeric_cols)) %>% summarise(across(everything(), sd))
+
+  scale_with_train_params <- function(df) {
+    df %>% mutate(across(
+      all_of(numeric_cols),
+      ~ (. - train_means[[cur_column()]]) / train_sds[[cur_column()]]
+    ))
+  }
+
+  train_scaled <- scale_with_train_params(train)
+  test_scaled  <- scale_with_train_params(test)
+
+  # ── 3. Build model matrices ───────────────────────────────────────────────
+  x_train <- train_scaled %>%
+    select(-Revenue) %>%
+    model.matrix(~ ., data = .) %>%
+    .[, -1]   # drop intercept column added by model.matrix
+  y_train <- as.numeric(train_scaled$Revenue)   # glmnet needs numeric 0/1
+
+  x_test <- test_scaled %>%
+    select(-Revenue) %>%
+    model.matrix(~ ., data = .) %>%
+    .[, -1]
+  y_test <- test_scaled$Revenue   # keep as factor for confusionMatrix later
+
+  # ── 4. Cross-validated LASSO to choose lambda ─────────────────────────────
+  message("Fitting cross-validated LASSO...")
+  cv_lasso <- cv.glmnet(
+    x_train, y_train,
+    family      = "binomial",
+    alpha       = 1,
+    type.measure = "auc"
+  )
+  cv_auc <- max(cv_lasso$cvm)
+  best_lambda <- cv_lasso$lambda.min
+  message(paste("Best CV AUC:", round(cv_auc, 4), "| Best lambda:", round(best_lambda, 6)))
+
+  # ── 5. Save CV lambda plot ────────────────────────────────────────────────
+  cv_plot_path <- file.path(output_dir, "lasso_cv_plot.png")
+  png(cv_plot_path, width = 800, height = 500)
+  plot(cv_lasso, main = "Cross-Validated AUC vs. log(lambda)")
+  dev.off()
+  message(paste("Saved:", cv_plot_path))
+
+  # ── 6. Fit final model on full training set ───────────────────────────────
+  final_lasso <- glmnet(
+    x_train, y_train,
+    family = "binomial",
+    alpha  = 1,
+    lambda = best_lambda
+  )
+
+  # ── 7. Predict on test set ────────────────────────────────────────────────
+  lasso_test_pred_prob <- predict(
+    final_lasso, newx = x_test,
+    s = "lambda.min", type = "response"
+  ) %>% as.numeric()
+
+  lasso_test_pred_class <- factor(
+    ifelse(lasso_test_pred_prob > 0.5, "Yes", "No"),
+    levels = c("No", "Yes")
+  )
+
+  # ── 8. ROC curve + AUC ───────────────────────────────────────────────────
+  roc_obj <- roc(
+    test$Revenue, lasso_test_pred_prob,
+    levels    = c("No", "Yes"),
+    direction = "<"
+  )
+  test_auc <- as.numeric(auc(roc_obj))
+  message(paste("Test AUC:", round(test_auc, 4)))
+
+  # Save ROC curve plot
+  roc_plot_path <- file.path(output_dir, "roc_curve.png")
+  png(roc_plot_path, width = 700, height = 600)
+  plot(
+    roc_obj,
+    col  = "#2c7bb6",
+    lwd  = 2,
+    main = paste0("ROC Curve — Test AUC = ", round(test_auc, 3))
+  )
+  abline(a = 1, b = -1, lty = 2, col = "grey60")
+  dev.off()
+  message(paste("Saved:", roc_plot_path))
+
+  # ── 9. Confusion matrix ───────────────────────────────────────────────────
+  cm <- confusionMatrix(
+    lasso_test_pred_class,
+    factor(test$Revenue, levels = c("No", "Yes")),
+    positive = "Yes"
+  )
+
+  # Save confusion matrix as a tidy CSV table
+  cm_table <- as.data.frame(cm$table)
+  colnames(cm_table) <- c("Predicted", "Actual", "Count")
+  cm_table_path <- file.path(output_dir, "confusion_matrix.csv")
+  write_csv(cm_table, cm_table_path)
+  message(paste("Saved:", cm_table_path))
+
+  # ── 10. Summary metrics table ─────────────────────────────────────────────
+  accuracy     <- cm$overall["Accuracy"]
+  precision    <- cm$byClass["Precision"]
+  recall       <- cm$byClass["Recall"]
+  f1           <- cm$byClass["F1"]
+
+  metrics <- tibble(
+    Metric    = c("CV AUC (lambda.min)", "Test AUC", "Test Accuracy",
+                  "Test Precision", "Test Recall", "Test F1"),
+    Value     = round(c(cv_auc, test_auc, accuracy, precision, recall, f1), 4)
+  )
+  metrics_path <- file.path(output_dir, "model_metrics.csv")
+  write_csv(metrics, metrics_path)
+  message(paste("Saved:", metrics_path))
+  print(metrics)
+
+  # ── 11. Selected coefficients table ──────────────────────────────────────
+  coef_mat   <- coef(final_lasso, s = best_lambda)
+  coef_df    <- as.data.frame(as.matrix(coef_mat))
+  coef_df    <- tibble(Feature = rownames(coef_df), Coefficient = coef_df[, 1]) %>%
+    filter(Coefficient != 0, Feature != "(Intercept)") %>%
+    arrange(desc(abs(Coefficient)))
+
+  coef_path <- file.path(output_dir, "lasso_coefficients.csv")
+  write_csv(coef_df, coef_path)
+  message(paste("Saved:", coef_path))
+
+  message("Done! All results saved to: ", output_dir)
+}
+
+main(opt$train, opt$test, opt$output_dir)


### PR DESCRIPTION
## Changes
- `src/04_model.R`: LASSO logistic regression script using docopt. 
  Takes train/test CSVs as input, saves model metrics, ROC curve, 
  confusion matrix, and coefficient table to results/
- `reports/fragments/06_data_modelling.qmd`: modelling section of report
- `reports/fragments/07_discussion.qmd`: discussion section of report

## To test
Rscript src/04_model.R \
  --train=data/processed/train.csv \
  --test=data/processed/test.csv \
  --output_dir=results/