### PR TITLE
feat: add scale_with_train_params function and tests

### DIFF
--- a/src/06_scale_with_train_params.R
+++ b/src/06_scale_with_train_params.R
@@ -1,0 +1,53 @@
+#' Scale training and test data using training set parameters
+#'
+#' Standardizes both the training and test feature matrices using the
+#' column-wise means and standard deviations computed from the training set
+#' only. This prevents data leakage from the test set into the scaling step.
+#'
+#' @param X_train A numeric data frame of training features.
+#' @param X_test A numeric data frame of test features.
+#'   Must have the same column names as \code{X_train}.
+#'
+#' @return A named list with two elements:
+#' \itemize{
+#'   \item \code{X_train_scaled}: The scaled training data frame.
+#'   \item \code{X_test_scaled}: The scaled test data frame, using training parameters.
+#' }
+#' @export
+#'
+#' @examples
+#' # train <- data.frame(a = c(1, 2, 3), b = c(10, 20, 30))
+#' # test  <- data.frame(a = c(4, 5),    b = c(40, 50))
+#' # result <- scale_with_train_params(train, test)
+#' # result$X_train_scaled
+#' # result$X_test_scaled
+scale_with_train_params <- function(X_train, X_test) {
+  if (!is.data.frame(X_train)) {
+    stop("`X_train` must be a data frame.")
+  }
+  if (!is.data.frame(X_test)) {
+    stop("`X_test` must be a data frame.")
+  }
+  if (!identical(colnames(X_train), colnames(X_test))) {
+    stop("`X_train` and `X_test` must have the same column names in the same order.")
+  }
+  if (nrow(X_train) == 0) {
+    stop("`X_train` must not be empty.")
+  }
+
+  train_means <- colMeans(X_train)
+  train_sds <- apply(X_train, 2, sd)
+
+  if (any(train_sds == 0)) {
+    stop("One or more columns in `X_train` have zero variance and cannot be scaled.")
+  }
+
+  scale_df <- function(df) {
+    as.data.frame(scale(df, center = train_means, scale = train_sds))
+  }
+
+  list(
+    X_train_scaled = scale_df(X_train),
+    X_test_scaled = scale_df(X_test)
+  )
+}

--- a/tests/testthat/helper-scale-with-train-params.R
+++ b/tests/testthat/helper-scale-with-train-params.R
@@ -1,0 +1,24 @@
+source("../../src/06_scale_with_train_params.R")
+
+# Normal case
+train_normal <- data.frame(a = c(1, 2, 3, 4, 5), b = c(10, 20, 30, 40, 50))
+test_normal  <- data.frame(a = c(6, 7),           b = c(60, 70))
+
+# Single column
+train_single <- data.frame(a = c(1, 2, 3))
+test_single  <- data.frame(a = c(4, 5))
+
+# Mismatched column names
+train_mismatch <- data.frame(a = c(1, 2, 3))
+test_mismatch  <- data.frame(b = c(4, 5))
+
+# Zero variance column
+train_zero_var <- data.frame(a = c(5, 5, 5), b = c(1, 2, 3))
+test_zero_var  <- data.frame(a = c(5, 6),    b = c(4, 5))
+
+# Empty train
+train_empty <- data.frame(a = numeric(0))
+test_empty  <- data.frame(a = c(1, 2))
+
+# Non-data-frame inputs
+not_a_df <- matrix(c(1, 2, 3), nrow = 3)

--- a/tests/testthat/test-scale-with-train-params.R
+++ b/tests/testthat/test-scale-with-train-params.R
@@ -1,0 +1,72 @@
+library(testthat)
+
+test_that("scaled training data has mean ~0 and sd ~1 per column", {
+  result <- scale_with_train_params(train_normal, test_normal)
+
+  col_means <- colMeans(result$X_train_scaled)
+  col_sds   <- apply(result$X_train_scaled, 2, sd)
+
+  expect_true(all(abs(col_means) < 1e-10))
+  expect_true(all(abs(col_sds - 1) < 1e-10))
+})
+
+test_that("test data is scaled using training parameters, not its own", {
+  result <- scale_with_train_params(train_single, test_single)
+
+  train_mean <- mean(c(1, 2, 3))
+  train_sd   <- sd(c(1, 2, 3))
+  expected   <- (c(4, 5) - train_mean) / train_sd
+
+  expect_equal(result$X_test_scaled$a, expected)
+})
+
+test_that("returns a list with correct names", {
+  result <- scale_with_train_params(train_normal, test_normal)
+
+  expect_type(result, "list")
+  expect_named(result, c("X_train_scaled", "X_test_scaled"))
+})
+
+test_that("output data frames have correct dimensions", {
+  result <- scale_with_train_params(train_normal, test_normal)
+
+  expect_equal(nrow(result$X_train_scaled), nrow(train_normal))
+  expect_equal(nrow(result$X_test_scaled),  nrow(test_normal))
+  expect_equal(ncol(result$X_train_scaled), ncol(train_normal))
+  expect_equal(ncol(result$X_test_scaled),  ncol(test_normal))
+})
+
+test_that("errors when X_train is not a data frame", {
+  expect_error(
+    scale_with_train_params(not_a_df, test_normal),
+    "`X_train` must be a data frame."
+  )
+})
+
+test_that("errors when X_test is not a data frame", {
+  expect_error(
+    scale_with_train_params(train_normal, not_a_df),
+    "`X_test` must be a data frame."
+  )
+})
+
+test_that("errors when column names do not match", {
+  expect_error(
+    scale_with_train_params(train_mismatch, test_mismatch),
+    "must have the same column names"
+  )
+})
+
+test_that("errors when X_train has zero variance column", {
+  expect_error(
+    scale_with_train_params(train_zero_var, test_zero_var),
+    "zero variance"
+  )
+})
+
+test_that("errors when X_train is empty", {
+  expect_error(
+    scale_with_train_params(train_empty, test_empty),
+    "`X_train` must not be empty."
+  )
+})


### PR DESCRIPTION
## Summary
Adds the `scale_with_train_params` function and its associated tests for Milestone 3.

## Changes
- `src/06_scale_with_train_params.R`: A function that standardizes training and test 
  data using only the training set's column-wise means and standard deviations. 
  This ensures no data leakage from the test set into the scaling step.
- `tests/testthat/helper-scale-with-train-params.R`: Shared test data and setup 
  used across all tests.
- `tests/testthat/test-scale-with-train-params.R`: 9 unit tests covering correct 
  output structure, correct scaling values, and error handling for invalid inputs.

## Related Issue
Closes #63
Closes #64